### PR TITLE
Use heroku/heroku:18-cnb instead of heroku/pack:18

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -1,7 +1,7 @@
 [stack]
 id = "heroku-18"
-build-image = "heroku/pack:18-build"
-run-image = "heroku/pack:18"
+build-image = "heroku/heroku:18-cnb-build"
+run-image = "heroku/heroku:18-cnb"
 
 [lifecycle]
 version = "0.9.3"


### PR DESCRIPTION
`heroku/pack:18` is no longer routinely published. `heroku/heroku:18-cnb` and `heroku/heroku:18-cnb-build` are the new homes for the CNB compatible stack images.